### PR TITLE
Tiny correction on footer (see description and screenshot)

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -3,7 +3,7 @@
 }
 
 .footer {
-  background: #FFE4E3;
+  background: $fluent-chinese-pink;
   color: rgba(0,0,0,0.3);
   border-color: rgba(0,0,0,0.3);
   /* Footer Position */
@@ -76,13 +76,14 @@
 
 .footer-copyright {
   text-align: center;
-  background: #E53935;
+  background: $fluent-chinese-red;
   padding: 10px 0px;
   bottom: 0;
   position: fixed;
   width: 100%;
   height: 30px;
   font-size: 10px;
+  color: white;
 }
 
 .footer-copyright .fa-copyright {


### PR DESCRIPTION
refactored colour of the background in the css by using the global variables' name and changed the colour of the copyright to white
<img width="1680" alt="Screenshot 2022-03-15 at 16 54 37" src="https://user-images.githubusercontent.com/30413474/158430522-3321b620-0edd-41e4-9e8c-2a10c7a886c4.png">
