### PR TITLE
made 'login' and 'about us' dark-grey in navbar when not on homepage

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -25,7 +25,11 @@
 }
 
 .navbar-light .navbar-nav .nav-link {
-    color: white;
+  color: white;
+}
+
+#not-on-homepage {
+  color: $dark-grey;
 }
 
 .active {

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -41,10 +41,10 @@
         </li>
       <% else %>
         <li class="nav-item">
-          <%= link_to "Login", new_user_session_path, class: "nav-link #{controller.controller_name == 'pages' ? '' : 'active'}" %>
+          <%= link_to "Login", new_user_session_path, class: "nav-link #{controller.controller_name == 'pages' ? '' : 'active'}", id: "#{controller.controller_name == 'pages' && controller.action_name == 'home' ? '' : 'not-on-homepage'}"  %>
         </li>
         <li class="nav-item">
-          <%= link_to "About Us", about_path, class: "nav-link #{controller.controller_name == 'pages' && controller.action_name == 'about' ? 'active' : ''}" %>
+          <%= link_to "About Us", about_path, class: "nav-link #{controller.controller_name == 'pages' && controller.action_name == 'about' ? 'active' : ''}", id: "#{controller.controller_name == 'pages' && controller.action_name == 'home' ? '' : 'not-on-homepage'}" %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
![Screenshot 2022-03-16 at 23 32 07](https://user-images.githubusercontent.com/30413474/158708450-a70f3eba-a2f0-4fd2-971d-a0c13a7192ef.png)
![Screenshot 2022-03-16 at 23 32 15](https://user-images.githubusercontent.com/30413474/158708458-7707418f-1144-455b-8a6f-3390404dcdcc.png)

